### PR TITLE
Update RFC template

### DIFF
--- a/content/0000-template/rfc.md
+++ b/content/0000-template/rfc.md
@@ -41,7 +41,8 @@ with features that are currently underway.]
 
 [If the scope of the work in this RFC is to take longer than a single
 engineering sprint, include specific deliverables, ideally one or more for each
-sprint.]
+sprint. Ensure each deliverable represents a complete, usable piece of
+functionality, not just a work stream or list of tasks.]
 
 * [Insert date of deliverable, in T+*X* weeks format]: [Describe the
   deliverable, including changes and refactors required from previous

--- a/content/0000-template/rfc.md
+++ b/content/0000-template/rfc.md
@@ -37,33 +37,44 @@ introduce any new concepts at a high level.]
 scope of work including time or size estimates. Include any potential conflicts
 with features that are currently underway.]
 
-## Drawbacks
+### Deliverables
 
-[Why should we _not_ include this change in the product?]
+[If the scope of the work in this RFC is to take longer than a single
+engineering sprint, include specific deliverables, ideally one or more for each
+sprint.]
+
+* [Insert date of deliverable, in T+*X* weeks format]: [Describe the
+  deliverable, including changes and refactors required from previous
+  deliverables.]
+
+### Operational impact
+
+[Does this work require changes to our infrastructure or operations? Include any
+increase or decrease to security surface areas or additional requirements for
+system metrics and monitoring.]
 
 ## Rationale and alternatives
 
 ### Why is this design the best in the space of possible designs?
 
-[...]
-
-### What other designs have been considered and what is the rationale for not choosing them?
-
-[...]
+[Describe the benefits, both to product and engineering, by implementing this
+solution. Include a comparison of alternative designs as part of the narrative
+if possible.]
 
 ### What is the impact of not doing this?
 
 [...]
 
-### What specific risks are associated with this design?
+## Drawbacks
 
-[...]
+[Why should we _not_ include this change in the product? What specific risks are
+associated with this design?]
 
 ## Success criteria
 
-[What will we observe when this change is completely implemented? What metrics
-can we use to measure success? Can we integrate any learnings into future
-processes?]
+[What will we observe when this change is completely implemented? What product
+metrics can we use to measure success? Can we integrate any learnings into
+future processes?]
 
 ## Unresolved questions
 


### PR DESCRIPTION
After a little over a year of using our RFC process, I am proposing some small but hopefully valuable adjustments to the template. Namely:

* The engineering-level explanation should include specific deliverables for significant scopes of work.
* The engineering-level explanation should be explicit about any required operational changes.
* The rationale sections about why the design is the best and what alternatives were considered are so similar in narrative that it makes more sense for them to be a single section.
* The drawbacks and "specific risks" sections were also similar and have been merged.

[Rendered](https://github.com/puppetlabs/relay-rfcs/blob/improvements/template-pass/content/0000-template/rfc.md)